### PR TITLE
add GITHUB_API_URL variable

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,10 @@ inputs:
     description: Fallback conclusion
     required: false
     default: skipped
+  GITHUB_API_URL:
+    description: GITHUB API URL
+    required: false
+    default: https://api.github.com
 
 outputs:
   conclusion:


### PR DESCRIPTION
## Description: 概要
<!-- Please describe purpose of change or related Issue number -->
<!-- 変更の目的 もしくは 関連する Issue 番号 -->

If you are using Github Enterprise, the domain of the api endpoint may not be api.github.com.
Allows you to specify an arbitrary endpoint url

## Changes: 変更内容
<!-- Detail of changes (please add screenshots if applicable) -->
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
Allow the GITHUB_API_URL to determine the api endpoint to be set arbitrarily

https://github.com/octokit/action.js/blob/master/src/index.ts#L17

<!-- START pr-commits -->
<!-- END pr-commits -->

## Expected Impact: 影響範囲
<!-- e.g. I changed this function, which might be affect that function. -->
<!-- この関数を変更したのでこの機能にも影響がある、など -->
GITHUB_API_URL can now be set, but the default value is api.github.com, so it does not affect the existing behavior.

## Operating Requirements: 動作要件
<!-- e.g. Environment variables / Dependencies / DB updates -->
<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->

## Additional context: 補足
<!-- e.g. Point or review / Cautions when trying in a local environment -->
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
