### PR TITLE
fix: ensure all jobs that we consider are completed

### DIFF
--- a/src/fixtures/actions.list.jobs5.json
+++ b/src/fixtures/actions.list.jobs5.json
@@ -1,0 +1,118 @@
+{
+  "total_count": 2,
+  "jobs": [
+    {
+      "id": 399444495,
+      "run_id": 29679449,
+      "run_url": "https://api.github.com/repos/octo-org/octo-repo/actions/runs/29679449",
+      "node_id": "MDEyOldvcmtmbG93IEpvYjM5OTQ0NDQ5Ng==",
+      "head_sha": "f83a356604ae3c5d03e1b46ef4d1ca77d64a90b0",
+      "url": "https://api.github.com/repos/octo-org/octo-repo/actions/jobs/399444495",
+      "html_url": "https://github.com/octo-org/octo-repo/runs/399444495",
+      "status": "in_progress",
+      "conclusion": null,
+      "started_at": "2020-01-20T17:42:40Z",
+      "completed_at": "2020-01-20T17:44:39Z",
+      "name": "build",
+      "steps": [],
+      "check_run_url": "https://api.github.com/repos/octo-org/octo-repo/check-runs/399444496"
+    },
+    {
+      "id": 399444496,
+      "run_id": 29679449,
+      "run_url": "https://api.github.com/repos/octo-org/octo-repo/actions/runs/29679449",
+      "node_id": "MDEyOldvcmtmbG93IEpvYjM5OTQ0NDQ5Ng==",
+      "head_sha": "f83a356604ae3c5d03e1b46ef4d1ca77d64a90b0",
+      "url": "https://api.github.com/repos/octo-org/octo-repo/actions/jobs/399444496",
+      "html_url": "https://github.com/octo-org/octo-repo/runs/399444496",
+      "status": "completed",
+      "conclusion": "success",
+      "started_at": "2020-01-20T17:42:40Z",
+      "completed_at": "2020-01-20T17:44:39Z",
+      "name": "build",
+      "steps": [
+        {
+          "name": "Set up job",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 1,
+          "started_at": "2020-01-20T09:42:40.000-08:00",
+          "completed_at": "2020-01-20T09:42:41.000-08:00"
+        },
+        {
+          "name": "Run actions/checkout@v2",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 2,
+          "started_at": "2020-01-20T09:42:41.000-08:00",
+          "completed_at": "2020-01-20T09:42:45.000-08:00"
+        },
+        {
+          "name": "Set up Ruby",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 3,
+          "started_at": "2020-01-20T09:42:45.000-08:00",
+          "completed_at": "2020-01-20T09:42:45.000-08:00"
+        },
+        {
+          "name": "Run actions/cache@v2",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 4,
+          "started_at": "2020-01-20T09:42:45.000-08:00",
+          "completed_at": "2020-01-20T09:42:48.000-08:00"
+        },
+        {
+          "name": "Install Bundler",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 5,
+          "started_at": "2020-01-20T09:42:48.000-08:00",
+          "completed_at": "2020-01-20T09:42:52.000-08:00"
+        },
+        {
+          "name": "Install Gems",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 6,
+          "started_at": "2020-01-20T09:42:52.000-08:00",
+          "completed_at": "2020-01-20T09:42:53.000-08:00"
+        },
+        {
+          "name": "Run Tests",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 7,
+          "started_at": "2020-01-20T09:42:53.000-08:00",
+          "completed_at": "2020-01-20T09:42:59.000-08:00"
+        },
+        {
+          "name": "Deploy to Heroku",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 8,
+          "started_at": "2020-01-20T09:42:59.000-08:00",
+          "completed_at": "2020-01-20T09:44:39.000-08:00"
+        },
+        {
+          "name": "Post actions/cache@v2",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 16,
+          "started_at": "2020-01-20T09:44:39.000-08:00",
+          "completed_at": "2020-01-20T09:44:39.000-08:00"
+        },
+        {
+          "name": "Complete job",
+          "status": "completed",
+          "conclusion": "success",
+          "number": 17,
+          "started_at": "2020-01-20T09:44:39.000-08:00",
+          "completed_at": "2020-01-20T09:44:39.000-08:00"
+        }
+      ],
+      "check_run_url": "https://api.github.com/repos/octo-org/octo-repo/check-runs/399444496"
+    }
+  ]
+}

--- a/src/process.test.ts
+++ b/src/process.test.ts
@@ -53,6 +53,19 @@ describe('getJobs', () => {
 
     expect(jobs).toHaveLength(2);
   });
+
+  it('should retry a retrieval if any jobs are incomplete', async() => {
+    nock('https://api.github.com')
+      .persist()
+      .get('/repos/hello/world/actions/runs/123/jobs')
+      .reply(200, () => getApiFixture(fixtureRootDir, 'actions.list.jobs5'))
+      .get('/repos/hello/world/actions/runs/123/jobs')
+      .reply(200, () => getApiFixture(fixtureRootDir, 'actions.list.jobs1'));
+
+    const jobs = await getJobs(octokit, context);
+    const incomplete = jobs.filter(job => job.status !== 'completed' && job.conclusion === null);
+    expect(incomplete).toHaveLength(0);
+  }, 100000);
 });
 
 describe('getJobConclusions', () => {

--- a/src/process.ts
+++ b/src/process.ts
@@ -6,17 +6,32 @@ import { setOutput, exportVariable, getInput } from '@actions/core';
 import { Utils } from '@technote-space/github-action-helper';
 import { CONCLUSIONS } from './constant';
 
+
 type ActionsListJobsForWorkflowRunResponseData = components['schemas']['job'];
 
 export const getTargetRunId = (context: Context): number => /^\d+$/.test(getInput('TARGET_RUN_ID')) ? Number(getInput('TARGET_RUN_ID')) : context.runId;
 
-export const getJobs = async(octokit: Octokit, context: Context): Promise<Array<ActionsListJobsForWorkflowRunResponseData>> => octokit.paginate(
-  octokit.rest.actions.listJobsForWorkflowRun,
-  {
-    ...context.repo,
-    'run_id': getTargetRunId(context),
-  },
-);
+const MAX_TRIES = 10;
+const RETRY_BACKOFF_MS = 2000;
+
+export const getJobs = async(octokit: Octokit, context: Context): Promise<Array<ActionsListJobsForWorkflowRunResponseData>> => {
+  for (let i = 0; i < MAX_TRIES; i++) {
+    const jobs = await octokit.paginate(
+      octokit.rest.actions.listJobsForWorkflowRun,
+      {
+        ...context.repo,
+        'run_id': getTargetRunId(context),
+      },
+    );
+    if (jobs.some(job => job.status !== 'completed' && job.conclusion === null)) {
+      console.warn('Not all jobs have completed yet', jobs);
+      await new Promise(r => setTimeout(r, RETRY_BACKOFF_MS));
+      continue;
+    }
+    return jobs;
+  }
+  throw new Error(`Could not retrieve completed jobs after ${MAX_TRIES} attempts`);
+};
 
 export const getJobConclusions = (jobs: Array<{ conclusion: string | null }>): Array<string> => Utils.uniqueArray(
   jobs
@@ -31,7 +46,7 @@ export const getWorkflowConclusion = (conclusions: Array<string>): string =>
       CONCLUSIONS.filter(conclusion => conclusions.includes(conclusion)).slice(-1)[0] ?? getInput('FALLBACK_CONCLUSION');
 
 export const execute = async(logger: Logger, octokit: Octokit, context: Context): Promise<void> => {
-  const jobs        = await getJobs(octokit, context);
+  const jobs = await getJobs(octokit, context);
   const conclusions = getJobConclusions(jobs);
   const conclusion  = getWorkflowConclusion(conclusions);
 


### PR DESCRIPTION
## Description: 概要

This PR fixes #107 by adding a check for incomplete jobs with a backoff-and-retry loop, which should ensure conclusions are drawn only from consistent data.

Unfortunately, the test that I added for this doesn't function correctly and I can't tell if it's me holding `nock` wrong (I'm not a JS developer normally), or a real bug in the code. I would appreciate a look from somebody who knows what's going on, and am happy to fix it if you can tell me what I'm doing wrong!

## Changes: 変更内容

* Added a test for behavior with not-yet-completed jobs.
* Added a retry loop with a 2-second backoff that retries when any jobs returned from the github API are in an unfinished state yet.

## Expected Impact: 影響範囲

Fixes #107 

## Operating Requirements: 動作要件

None

## Additional context: 補足

None